### PR TITLE
jsonのインデント処理をなくす

### DIFF
--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -611,7 +611,11 @@ func getLowPricedChair(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	return c.JSON(http.StatusOK, ChairListResponse{Chairs: chairs})
+	jsonResponse, err := json.Marshal(ChairListResponse{Chairs: chairs})
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	return c.JSONBlob(http.StatusOK, jsonResponse)
 }
 
 func getEstateDetail(c echo.Context) error {
@@ -632,7 +636,11 @@ func getEstateDetail(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	return c.JSON(http.StatusOK, estate)
+	jsonResponse, err := json.Marshal(estate)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	return c.JSONBlob(http.StatusOK, jsonResponse)
 }
 
 func getRange(cond RangeCondition, rangeID string) (*Range, error) {
@@ -827,7 +835,11 @@ func getLowPricedEstate(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	return c.JSON(http.StatusOK, EstateListResponse{Estates: estates})
+	jsonResponse, err := json.Marshal(EstateListResponse{Estates: estates})
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	return c.JSONBlob(http.StatusOK, jsonResponse)
 }
 
 func searchRecommendedEstateWithChair(c echo.Context) error {
@@ -893,7 +905,11 @@ func searchEstateNazotte(c echo.Context) error {
 	re.Estates = estatesInPolygon
 	re.Count = int64(len(re.Estates))
 
-	return c.JSON(http.StatusOK, re)
+	jsonResponse, err := json.Marshal(re)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	return c.JSONBlob(http.StatusOK, jsonResponse)
 }
 
 func postEstateRequestDocument(c echo.Context) error {

--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -535,7 +535,11 @@ func searchChairs(c echo.Context) error {
 
 	res.Chairs = chairs
 
-	return c.JSON(http.StatusOK, res)
+	jsonResponse, err := json.Marshal(res)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	return c.JSONBlob(http.StatusOK, jsonResponse)
 }
 
 func buyChair(c echo.Context) error {
@@ -803,7 +807,11 @@ func searchEstates(c echo.Context) error {
 
 	res.Estates = estates
 
-	return c.JSON(http.StatusOK, res)
+	jsonResponse, err := json.Marshal(res)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	return c.JSONBlob(http.StatusOK, jsonResponse)
 }
 
 func getLowPricedEstate(c echo.Context) error {


### PR DESCRIPTION
```
2024/11/23 15:42:59 bench.go:102: 最終的な負荷レベル: 10
{"pass":true,"score":1765,"messages":[],"reason":"OK","language":"go"}
```

framegraphを見るとjson.Indentがリソースを食っていたので、インデント処理はなくすことに
しかし、そもそものボトルネックがアプリ側ではなかったのであまり効果はなし