### PR TITLE
estate/searchのレスポンスごとキャッシュ

### DIFF
--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -183,7 +183,7 @@ var chairCountCache = NewCountCache()
 // estate件数のキャッシュ
 var estateCountCache = NewCountCache()
 
-// 検索結果の件数をキャッシュするための仕組み
+// レスポンスごとキャッシュするための仕組み
 type SearchCache struct {
 	mu    sync.RWMutex
 	items map[string][]byte


### PR DESCRIPTION
```
2024/11/23 17:39:30 bench.go:102: 最終的な負荷レベル: 11
{"pass":true,"score":2470,"messages":[{"text":"GET /api/chair/search: リクエストに失敗しました (タ 
イムアウトしました)","count":1}],"reason":"OK","language":"go"}
```