### PR TITLE
アプリのdebugログを止める

### DIFF
--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -323,11 +323,11 @@ func main() {
 
 	// Echo instance
 	e := echo.New()
-	e.Debug = true
-	e.Logger.SetLevel(log.DEBUG)
+	e.Debug = false
+	e.Logger.SetLevel(log.ERROR)
 
 	// Middleware
-	e.Use(middleware.Logger())
+	// e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
 	// Initialize


### PR DESCRIPTION
```
2024/11/23 19:40:43 bench.go:102: 最終的な負荷レベル: 11
{"pass":true,"score":11005,"messages":[{"text":"GET /api/chair/search: レスポンスの内容が不正です","count":1},{"text":"POST /api/estate/nazotte: リクエストに失敗しました (タイムアウトしました)","count":1}],"reason":"OK","language":"go"}
```